### PR TITLE
chore: Use package.json as direct source for wasm releases (SQCORE-1233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Follow the instructions there, then:
 $ brew install \
   autoconf \
   automake \
+  jq \
   libsodium \
   libtool \
   multirust \

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -426,11 +426,10 @@ $(DIST_WASM_JS_TARGET):
 $(DIST_WASM_PC_TARGET):
 	@mkdir -p $(BUILD_DIST_WASM)
 	@cp -r wasm/. $(BUILD_DIST_WASM)
-	@rm -f $(BUILD_DIST_WASM)/package.json
 
+.PHONY: $(DIST_WASM_PKG_TARGET)
 $(DIST_WASM_PKG_TARGET):
-	@cat $(BUILD_DIST_WASM)/package.json.template | \
-		awk '{ gsub("AVS_VERSION", "$(DIST_WASM_PKG_VERSION)", $$0); print; }' > $@
+	(rm -f $@ && jq '.version = "$(DIST_WASM_PKG_VERSION)"' > $@) < $@
 
 $(DIST_WASM_WC_TARGET):
 	@mkdir -p $(BUILD_DIST_WASM)

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -20,5 +20,5 @@
     "prepack": "tsc && cp src/*.{js,d.ts} dist/",
     "test": "karma start"
   },
-  "version": "AVS_VERSION"
+  "version": "0"
 }


### PR DESCRIPTION
This allows an easier workflow for updates of the dependencies package-lock file.
Additional requirement for the build process is `jq`

When this is merged dependabot and manual updates of locked dependencies will be possible again and should follow in a separate step.