### PR TITLE
Feature/screenshare bw

### DIFF
--- a/include/avs_sdp.h
+++ b/include/avs_sdp.h
@@ -25,9 +25,11 @@ const char *sdp_sess2str(struct sdp_session *sess);
 
 const char *sdp_modify_offer(struct sdp_session *sess,
 			     enum icall_conv_type conv_type,
+			     bool screenshare,
 			     bool audio_cbr);
 const char *sdp_modify_answer(struct sdp_session *sess,
 			      enum icall_conv_type conv_type,
+			      bool screenshare,
 			      bool audio_cbr);
 
 int sdp_strip_video(char **sdp, enum icall_conv_type conv_type,

--- a/src/jsflow/jsflow.c
+++ b/src/jsflow/jsflow.c
@@ -962,11 +962,13 @@ static int jsflow_generate_offer_answer(struct iflow *flow,
 	if (isoffer) {
 		sdp_modify_offer(sess,
 				 jsflow->conv_type,
+				 jsflow->vstate == ICALL_VIDEO_STATE_SCREENSHARE,
 				 jsflow->audio.req_local_cbr);
 	}
 	else {
 		sdp_modify_answer(sess,
 				  jsflow->conv_type,
+				  jsflow->vstate == ICALL_VIDEO_STATE_SCREENSHARE,
 				  jsflow->audio.req_local_cbr);
 	}
 	
@@ -1449,11 +1451,17 @@ void pc_local_sdp_handler(int self, int err,
 	/* Modify SDP here */
 	if (isoffer) {
 		sdp_dup(&sess, flow->conv_type, sdp, true);
-		modsdp = sdp_modify_offer(sess, flow->conv_type, flow->audio.req_local_cbr);
+		modsdp = sdp_modify_offer(sess,
+					  flow->conv_type,
+					  flow->vstate == ICALL_VIDEO_STATE_SCREENSHARE,
+					  flow->audio.req_local_cbr);
 	}
 	else if (streq(type, "answer")) {
 		sdp_dup(&sess, flow->conv_type, sdp, false);		
-		modsdp = sdp_modify_answer(sess, flow->conv_type, flow->audio.req_local_cbr);
+		modsdp = sdp_modify_answer(sess,
+					   flow->conv_type,
+					   flow->vstate == ICALL_VIDEO_STATE_SCREENSHARE,
+					   flow->audio.req_local_cbr);
 	}
 	else {
 		str_dup((char **)&modsdp, sdp);

--- a/src/peerflow/peerflow.cpp
+++ b/src/peerflow/peerflow.cpp
@@ -1650,7 +1650,10 @@ public:
 			}
 
 			sdp_check(sdp_str.c_str(), true, true, NULL, pf_norelay_handler, NULL, pf_);
-			sdp = sdp_modify_offer(sess, pf_->conv_type, pf_->audio.local_cbr);
+			sdp = sdp_modify_offer(sess,
+					       pf_->conv_type,
+					       pf_->vstate == ICALL_VIDEO_STATE_SCREENSHARE,
+					       pf_->audio.local_cbr);
 
 			info("SDP-fromPC: %s\n", sdp);
 			
@@ -1670,7 +1673,10 @@ public:
 			
 			sdp_check(sdp_str.c_str(), true, false, NULL, pf_norelay_handler, NULL, pf_);
 
-			sdp = sdp_modify_answer(sess, pf_->conv_type, pf_->audio.local_cbr);
+			sdp = sdp_modify_answer(sess,
+						pf_->conv_type,
+						pf_->vstate == ICALL_VIDEO_STATE_SCREENSHARE,
+						pf_->audio.local_cbr);
 			imod_sdp = sdp_interface(sdp, webrtc::SdpType::kAnswer);
 			pf_->peerConn->SetLocalDescription(
 					pf_->answerObserver,

--- a/src/sdp/sdp.c
+++ b/src/sdp/sdp.c
@@ -26,10 +26,8 @@
 #define MAX_NET_ID 5
 
 enum {
-      AUDIO_ONEONE_BANDWIDTH = 50,
-      AUDIO_GROUP_BANDWIDTH = 32,
-      VIDEO_ONEONE_BANDWIDTH = 800,
-      VIDEO_GROUP_BANDWIDTH = 600,
+      AUDIO_GROUP_BANDWIDTH = 50,
+      VIDEO_GROUP_BANDWIDTH = 1200,
 };
       
 
@@ -336,18 +334,13 @@ const char *sdp_modify_offer(struct sdp_session *sess,
 		struct sdp_media *sdpm = (struct sdp_media *)le->data;
 
 		if (streq(sdp_media_name(sdpm), "video") && !screenshare) {
-			uint32_t bw = conv_type == ICALL_CONV_TYPE_ONEONONE ?
-				VIDEO_ONEONE_BANDWIDTH : VIDEO_GROUP_BANDWIDTH;
-
-			sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, bw);
+            if (conv_type != ICALL_CONV_TYPE_ONEONONE){
+                sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, VIDEO_GROUP_BANDWIDTH);
+            }
 		}
 		else if (streq(sdp_media_name(sdpm), "audio")) {
-			uint32_t bw = conv_type == ICALL_CONV_TYPE_ONEONONE ?
-				AUDIO_ONEONE_BANDWIDTH : AUDIO_GROUP_BANDWIDTH;
-			sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, bw);
-
 			if (conv_type != ICALL_CONV_TYPE_ONEONONE) {
-
+                sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, AUDIO_GROUP_BANDWIDTH);
 				info("sdp_modify_offer: group mode, "
 				     "setting ptime\n");
 				sdp_media_set_lattr(sdpm, true, "ptime", "40");
@@ -406,16 +399,13 @@ const char *sdp_modify_answer(struct sdp_session *sess,
 		struct sdp_media *sdpm = (struct sdp_media *)le->data;
 		
 		if (streq(sdp_media_name(sdpm), "video") && !screenshare) {
-			uint32_t bw = conv_type == ICALL_CONV_TYPE_ONEONONE ?
-				VIDEO_ONEONE_BANDWIDTH : VIDEO_GROUP_BANDWIDTH;
-			sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, bw);
+            if(conv_type != ICALL_CONV_TYPE_ONEONONE) {
+                sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, VIDEO_GROUP_BANDWIDTH);
+            }
 		}
 		else if (streq(sdp_media_name(sdpm), "audio")) {
-			uint32_t bw = conv_type == ICALL_CONV_TYPE_ONEONONE ?
-				AUDIO_ONEONE_BANDWIDTH : AUDIO_GROUP_BANDWIDTH;
-			sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, bw);
-
 			if (conv_type != ICALL_CONV_TYPE_ONEONONE) {
+                sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, AUDIO_GROUP_BANDWIDTH);
 				const struct list *fmtl;
 				struct le *fle;
 

--- a/src/sdp/sdp.c
+++ b/src/sdp/sdp.c
@@ -26,8 +26,8 @@
 #define MAX_NET_ID 5
 
 enum {
-      AUDIO_GROUP_BANDWIDTH = 50,
-      VIDEO_GROUP_BANDWIDTH = 1200,
+      AUDIO_GROUP_BANDWIDTH = 32,
+      VIDEO_GROUP_BANDWIDTH = 600,
 };
       
 

--- a/src/sdp/sdp.c
+++ b/src/sdp/sdp.c
@@ -323,7 +323,7 @@ static void sdp_set_bandwidth(struct sdp_media *sdpm, bool screenshare)
     }
     else if (streq(sdp_media_name(sdpm), "audio")){
         sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, AUDIO_GROUP_BANDWIDTH);
-        info("sdp_modify_offer: group mode, setting ptime\n");
+        info("sdp_set_bandwidth: group mode, setting ptime\n");
         sdp_media_set_lattr(sdpm, true, "ptime", "40");
     }
 }

--- a/src/sdp/sdp.c
+++ b/src/sdp/sdp.c
@@ -316,6 +316,17 @@ int sdp_dup(struct sdp_session **sessp,
 	return sdp_dup_int(sessp, conv_type, sdp, offer, false);
 }
 
+static void sdp_set_bandwidth(struct sdp_media *sdpm, bool screenshare)
+{
+    if (streq(sdp_media_name(sdpm), "video") && !screenshare) {
+        sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, VIDEO_GROUP_BANDWIDTH);
+    }
+    else if (streq(sdp_media_name(sdpm), "audio")){
+        sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, AUDIO_GROUP_BANDWIDTH);
+        info("sdp_modify_offer: group mode, setting ptime\n");
+        sdp_media_set_lattr(sdpm, true, "ptime", "40");
+    }
+}
 
 const char *sdp_modify_offer(struct sdp_session *sess,
 			     enum icall_conv_type conv_type,
@@ -333,19 +344,11 @@ const char *sdp_modify_offer(struct sdp_session *sess,
 
 		struct sdp_media *sdpm = (struct sdp_media *)le->data;
 
-		if (streq(sdp_media_name(sdpm), "video") && !screenshare) {
-            if (conv_type != ICALL_CONV_TYPE_ONEONONE){
-                sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, VIDEO_GROUP_BANDWIDTH);
-            }
-		}
-		else if (streq(sdp_media_name(sdpm), "audio")) {
-			if (conv_type != ICALL_CONV_TYPE_ONEONONE) {
-                sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, AUDIO_GROUP_BANDWIDTH);
-				info("sdp_modify_offer: group mode, "
-				     "setting ptime\n");
-				sdp_media_set_lattr(sdpm, true, "ptime", "40");
-			}
+        if (conv_type != ICALL_CONV_TYPE_ONEONONE) {
+            sdp_set_bandwidth(sdpm, screenshare);
+        }
 
+		if (streq(sdp_media_name(sdpm), "audio")) {
 			debug("sdp_modify_offer: audio_cbr=%d\n", audio_cbr);
 			if (audio_cbr) {
 				const struct list *fmtl;
@@ -397,19 +400,16 @@ const char *sdp_modify_answer(struct sdp_session *sess,
 	for(le = medial->head; le; le = le->next) {
 
 		struct sdp_media *sdpm = (struct sdp_media *)le->data;
-		
-		if (streq(sdp_media_name(sdpm), "video") && !screenshare) {
-            if(conv_type != ICALL_CONV_TYPE_ONEONONE) {
-                sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, VIDEO_GROUP_BANDWIDTH);
-            }
-		}
-		else if (streq(sdp_media_name(sdpm), "audio")) {
+
+        if (conv_type != ICALL_CONV_TYPE_ONEONONE) {
+            sdp_set_bandwidth(sdpm, screenshare);
+        }
+
+		if (streq(sdp_media_name(sdpm), "audio")) {
 			if (conv_type != ICALL_CONV_TYPE_ONEONONE) {
-                sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, AUDIO_GROUP_BANDWIDTH);
-				const struct list *fmtl;
+                const struct list *fmtl;
 				struct le *fle;
 
-				sdp_media_set_lattr(sdpm, true, "ptime", "40");
 				fmtl = sdp_media_format_lst(sdpm, true);
 
 				LIST_FOREACH(fmtl, fle) {

--- a/src/sdp/sdp.c
+++ b/src/sdp/sdp.c
@@ -321,6 +321,7 @@ int sdp_dup(struct sdp_session **sessp,
 
 const char *sdp_modify_offer(struct sdp_session *sess,
 			     enum icall_conv_type conv_type,
+			     bool screenshare,
 			     bool audio_cbr)
 {
 	char *sdpres = NULL;
@@ -334,7 +335,7 @@ const char *sdp_modify_offer(struct sdp_session *sess,
 
 		struct sdp_media *sdpm = (struct sdp_media *)le->data;
 
-		if (streq(sdp_media_name(sdpm), "video")) {
+		if (streq(sdp_media_name(sdpm), "video") && !screenshare) {
 			uint32_t bw = conv_type == ICALL_CONV_TYPE_ONEONONE ?
 				VIDEO_ONEONE_BANDWIDTH : VIDEO_GROUP_BANDWIDTH;
 
@@ -393,6 +394,7 @@ const char *sdp_sess2str(struct sdp_session *sess)
 
 const char *sdp_modify_answer(struct sdp_session *sess,
 			      enum icall_conv_type conv_type,
+			      bool screenshare,
 			      bool audio_cbr)
 {
 	const struct list *medial;
@@ -403,7 +405,7 @@ const char *sdp_modify_answer(struct sdp_session *sess,
 
 		struct sdp_media *sdpm = (struct sdp_media *)le->data;
 		
-		if (streq(sdp_media_name(sdpm), "video")) {
+		if (streq(sdp_media_name(sdpm), "video") && !screenshare) {
 			uint32_t bw = conv_type == ICALL_CONV_TYPE_ONEONONE ?
 				VIDEO_ONEONE_BANDWIDTH : VIDEO_GROUP_BANDWIDTH;
 			sdp_media_set_lbandwidth(sdpm, SDP_BANDWIDTH_AS, bw);


### PR DESCRIPTION
----
#### Remove bandwidth limitations for 1:1 calls. 

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

----

# What's new in this PR?

Remove bandwidth limitations for 1:1 calls. The artificial bandwidth restriction is being removed to allow the WebRTC client to regulate the bandwidth. This will enable better resolution during screen sharing in 1:1 calls.

Needs releases with:

- [ ] GitHub link to other pull request

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1.  https://wearezeta.atlassian.net/browse/WPB-9950)
