### PR TITLE
fix: Change track ID parser and delete FID group remover

### DIFF
--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -1636,11 +1636,9 @@ function sdpCbrMap(sdp: string): string {
 	if(sdpLine.endsWith('sprop-stereo=0;useinbandfec=1')) {
 		outline = sdpLine + ";cbr=1";
 	}
-	else if (sdpLine.startsWith('a=ssrc-group:')) {
-	        outline = null;
-	}
-        if (outline != null) {
-            sdpLines.push(outline);
+
+    if (outline != null) {
+        sdpLines.push(outline);
 	}
     });
 
@@ -1930,10 +1928,10 @@ function extractSSRCs(pc: PeerConnection,
                       sdp: string) {
 
   sdp.split('\r\n').forEach(l => {
-    let m = l.match(/a=ssrc:(\d+) label:(.*)/)
+    let m = l.match(/a=ssrc:(\d+) msid:(.*) (.*)/)
     if (m) {
       let ssrc = m[1];
-      let label = m[2];
+      let label = m[3];
 
       pc.streams[ssrc] = label;
     }

--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -1629,20 +1629,28 @@ function sdpCbrMap(sdp: string): string {
     const sdpLines:  string[] = [];
     
     sdp.split('\r\n').forEach(sdpLine => {
-	let outline: string | null;
+      let outline: string | null;
 
-	outline = sdpLine;
+      outline = sdpLine;
 
-	if(sdpLine.endsWith('sprop-stereo=0;useinbandfec=1')) {
-		outline = sdpLine + ";cbr=1";
-	}
+      if(sdpLine.endsWith('sprop-stereo=0;useinbandfec=1')) {
+        outline = sdpLine + ";cbr=1";
+      }
+      else if (sdpLine.startsWith('a=ssrc-group:')) {
+        const group = sdpLine;
+        // in case of only one ssrc in group (no nack/rtx), remove attribute
+        const spaces = group.trim().split(' ').length;
+        if (spaces < 3) {
+          outline = null;
+        }
+      }
 
-    if (outline != null) {
+      if (outline != null) {
         sdpLines.push(outline);
-	}
-    });
+      }
+  });
 
-    return sdpLines.join('\r\n');
+  return sdpLines.join('\r\n');
 }
 
 function pc_SetMediaKey(hnd: number, index: number, current: number, keyPtr: number, keyLen: number) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The group FID is needed to identify source relation of RTX and  RTP. So we put it back and changed the way of parsing Remote Track ID to add a ID label on the receiving track. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
