### PR TITLE
reorder simulcast ids for firefox and deactivate low resolution for screen share

### DIFF
--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -924,10 +924,13 @@ function replace_track(pc: PeerConnection, newTrack: MediaStreamTrack) {
 	    else {			
 		const enabled = oldTrack.enabled;
 
-		newTrack.enabled = enabled;
-		sender.replaceTrack(newTrack);
-		sender.track.enabled = enabled;
+        // newTrack.enabled = enabled;
+        sender.replaceTrack(newTrack).then(() => {
+            if(!!sender && !!sender.track) {
+                sender.track.enabled = enabled
 		pc_log(LOG_LEVEL_INFO, `replace_track: kind=${newTrack.kind} enabled=${sender.track.enabled}`);
+            }
+        });
 
 		return true;
 	    }
@@ -992,39 +995,18 @@ function update_tracks(pc: PeerConnection, stream: MediaStream): Promise<void> {
             if (track.kind === 'video' && pc.conv_type !== CONV_TYPE_ONEONONE) {
                 const transceivers = rtc.getTransceivers();
                 for (const trans of transceivers) {
-                    if (trans.mid === 'video') {
+                    if (trans.mid === 'video' && !!trans.sender) {
                         pc_log(LOG_LEVEL_INFO, `update_tracks: adjust`)
-                        const params = trans.sender.getParameters()
+                        const {params, layerFound} = getEncodingParameter(trans.sender, pc.vstate === PC_VIDEO_STATE_SCREENSHARE)
 
-                        if (!params.encodings) {
-                            pc_log(LOG_LEVEL_INFO, `update_tracks: no params`)
-                            params.encodings = [];
-                        }
-
-                        let layerFound = false;
-                        params.encodings.forEach((coding) => {
-                            if(coding.rid === 'l') {
-                                //@ts-ignore
-                                coding.scalabilityMode = 'L1T1'
-                                coding.scaleResolutionDownBy = 4;
-                                coding.active = true;
-                                layerFound = true;
-                            }
-                            if(coding.rid === 'h') {
-                                //@ts-ignore
-                                coding.scalabilityMode = 'L1T1'
-                                coding.scaleResolutionDownBy = 1;
-                                coding.active = true;
-                                layerFound = true;
-                            }
-                        });
-
+                        pc_log(LOG_LEVEL_INFO, 'add track: ' + layerFound);
                         rtc.addTrack(track, stream)
                         if (layerFound) {
                             videoSenderUpdates.push(trans.sender.setParameters(params).catch((e) => pc_log(LOG_LEVEL_ERROR, `update_tracks: set params ${e}`))
-                                // Reinsert the track so that the changes are transferred to the track (needed for FF)
-                                .then(() => trans.sender.replaceTrack(track))
-                                .then())
+                                .then(() => {
+                                    pc_log(LOG_LEVEL_INFO, 'setParameters: ' + JSON.stringify(params));
+                                })
+                                .then());
                         }
                     }
                 }
@@ -1042,6 +1024,46 @@ function update_tracks(pc: PeerConnection, stream: MediaStream): Promise<void> {
     return Promise.all(videoSenderUpdates).catch(e => {
         pc_log(LOG_LEVEL_ERROR, `update_tracks: error=${e}`)
     }).then();
+}
+
+function getEncodingParameter(sender: RTCRtpSender, isScreenShare: boolean) {
+    pc_log(LOG_LEVEL_INFO, `update_tracks: adjust`)
+    const params = sender.getParameters()
+
+                        if (!params.encodings) {
+                            pc_log(LOG_LEVEL_INFO, `update_tracks: no params`)
+                            params.encodings = [];
+                        }
+
+                        let layerFound = false;
+                        params.encodings.forEach((coding) => {
+                            if(coding.rid === 'l') {
+            if(pc_env !== ENV_FIREFOX) {
+                                //@ts-ignore
+                                coding.scalabilityMode = 'L1T1'
+            }
+
+            if(pc_env === ENV_FIREFOX && isScreenShare) {
+                coding.active = false;
+            } else {
+                coding.active = true;
+            }
+                                coding.scaleResolutionDownBy = 4;
+                                layerFound = true;
+                            }
+                            if(coding.rid === 'h') {
+            if(pc_env !== ENV_FIREFOX) {
+                                //@ts-ignore
+                                coding.scalabilityMode = 'L1T1'
+            }
+
+                                coding.scaleResolutionDownBy = 1;
+                                coding.active = true;
+                                layerFound = true;
+                            }
+                        });
+
+    return {params, layerFound}
 }
 
 function sigState(stateStr: string) {
@@ -1688,6 +1710,18 @@ function sdpCbrMap(sdp: string): string {
           outline = null;
         }
       }
+      // reorder rids for firefox
+      else if (sdpLine.startsWith('a=simulcast:recv l;h') && pc_env === ENV_FIREFOX) {
+          outline = 'a=simulcast:recv h;l'
+      }
+
+      else if (sdpLine.startsWith('a=rid:l recv') && pc_env === ENV_FIREFOX) {
+          outline = 'a=rid:h recv';
+      }
+
+      else if (sdpLine.startsWith('a=rid:h recv') && pc_env === ENV_FIREFOX) {
+          outline = 'a=rid:l recv';
+      }
 
       if (outline != null) {
         sdpLines.push(outline);
@@ -1695,6 +1729,33 @@ function sdpCbrMap(sdp: string): string {
   });
 
   return sdpLines.join('\r\n');
+}
+
+function sdpRidReOrder (sdp: string): string {
+    const sdpLines:  string[] = [];
+
+    sdp.split('\r\n').forEach(sdpLine => {
+        let outline: string | null;
+
+        outline = sdpLine;
+
+        if (sdpLine.startsWith('a=simulcast:send h;l') && pc_env === ENV_FIREFOX) {
+            outline = 'a=simulcast:send l;h';
+        }
+
+        else if (sdpLine.startsWith('a=rid:h send') && pc_env === ENV_FIREFOX) {
+            outline = 'a=rid:l send';
+        }
+
+        else if (sdpLine.startsWith('a=rid:l send') && pc_env === ENV_FIREFOX) {
+            outline = 'a=rid:h send';
+        }
+
+        if (outline != null) {
+            sdpLines.push(outline);
+        }
+    });
+    return sdpLines.join('\r\n');
 }
 
 function pc_SetMediaKey(hnd: number, index: number, current: number, keyPtr: number, keyLen: number) {
@@ -2126,6 +2187,14 @@ function pc_LocalDescription(hnd: number, typePtr: number) {
       sdpStr = sdpMap(sdpStr, true, false);
   }
     
+    /* Ensure that we force CBR on the offer */
+    if (pc_env === ENV_FIREFOX && pc.conv_type == CONV_TYPE_CONFERENCE) {
+        sdpStr = sdpRidReOrder(sdpStr);
+    }
+
+    pc_log(LOG_LEVEL_INFO, `pc_LocalDescription: hnd=${sdpStr}`);
+
+
   const sdpLen = em_module.lengthBytesUTF8(sdpStr) + 1; // +1 for '\0'
   const ptr = em_module._malloc(sdpLen);
     


### PR DESCRIPTION
Firefox currently has an issue when the resolution is not negotiated from high to low. This is a fix to address the issue.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
