### PR TITLE
fix: undefined ssrca warnings [WPB-16289]

### DIFF
--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -2367,42 +2367,50 @@ function pc_GetLocalStats(hnd: number) {
     if (rx) {
       const ssrcs = rx.getSynchronizationSources();
       ssrcs.forEach(ssrc => {
-          let ssrca = "";
-	  let aulevel = 0;
+        let ssrca = "";
+        let aulevel = 0;
 
-	  if (typeof ssrc.audioLevel !== 'undefined')
-	      aulevel = ((ssrc.audioLevel * 512.0) | 0);
+        if (typeof ssrc.audioLevel !== 'undefined')
+          aulevel = ((ssrc.audioLevel * 512.0) | 0);
 
-	  if (pc.conv_type != CONV_TYPE_ONEONONE) {
-              const uinfo = uinfo_from_ssrca(pc, ssrc.source.toString());
-	      if (uinfo) {
-	         uinfo.audio_level = aulevel;
-	         ssrca = uinfo.ssrca;
-	      }
-	  }
+        if (pc.conv_type === CONV_TYPE_ONEONONE) {
+          ssrca = ssrc.source.toString();
+        }
+        else {
+          const uinfo = uinfo_from_ssrca(pc, ssrc.source.toString());
+          if (uinfo) {
+            uinfo.audio_level = aulevel;
+            ssrca = uinfo.ssrca;
+          }
+        }
 
-	  em_module.ccall(
-	    "pc_set_audio_level",
-	    null,
-	    ["number", "number", "number"],
-	    [pc.self, ssrca, aulevel]);
+        if (!!ssrca && ssrca !== "0") {
+          em_module.ccall(
+              "pc_set_audio_level",
+              null,
+              ["number", "number", "number"],
+              [pc.self, ssrca, aulevel]
+          );
+        }
       });
+
       const csrcs = rx.getContributingSources();
       csrcs.forEach(csrc => {
         const uinfo = uinfo_from_ssrca(pc, csrc.source.toString());
-	if (uinfo) {
-	  uinfo.audio_level = 0;
-	  if (typeof csrc.audioLevel !== 'undefined')
-	    uinfo.audio_level = ((csrc.audioLevel * 512.0) | 0);
+        if (uinfo) {
+          uinfo.audio_level = 0;
+          if (typeof csrc.audioLevel !== 'undefined')
+            uinfo.audio_level = ((csrc.audioLevel * 512.0) | 0);
 
-	  em_module.ccall(
-	    "pc_set_audio_level",
-	    null,
-	    ["number", "number", "number"],
-	    [pc.self, uinfo.ssrca, uinfo.audio_level]);
-	  }
-	});
-     }
+          em_module.ccall(
+              "pc_set_audio_level",
+              null,
+              ["number", "number", "number"],
+              [pc.self, uinfo.ssrca, uinfo.audio_level]
+          );
+        }
+      });
+    }
   });
 
   let self_audio_level = 0;


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

srcc could be undefined in group calls and so audio level cant determined. With this PR we fix that

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
