### PR TITLE
chore: update android publishing to target Sonatype Central

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,7 +211,7 @@ pipeline {
                         """
                     )
                 }
-            } 
+            }
         }
         stage('Upload to Github') {
             when {
@@ -267,14 +267,16 @@ pipeline {
             steps {
                 script {
                     echo '### Sign and upload to sonatype'
-                    withCredentials([ usernamePassword( credentialsId: 'android-sonatype-nexus', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD' ),
-                                        file(credentialsId: 'D599C1AA126762B1.asc', variable: 'PGP_PRIVATE_KEY_FILE'),
-                                        string(credentialsId: 'PGP_PASSPHRASE', variable: 'PGP_PASSPHRASE') ]) {
+                    withCredentials([
+                            usernamePassword( credentialsId: 'sonatype-central', usernameVariable: 'ORG_GRADLE_PROJECT_mavenCentralUsername', passwordVariable: 'ORG_GRADLE_PROJECT_mavenCentralPassword' ),
+                            string(credentialsId: 'sonatype-signing-key-password', variable: 'ORG_GRADLE_PROJECT_signingInMemoryKeyPassword')
+                            string(credentialsId: 'sonatype-signing-key', variable: 'ORG_GRADLE_PROJECT_signingInMemoryKey')
+                        ]) {
                         withMaven(maven: 'M3', jdk: 'JDK17') {
                             sh(
                                 script: """
                                     touch local.properties
-                                    version=$version ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+                                    ORG_GRADLE_PROJECT_VERSION_NAME=$version ./gradlew publishAndReleaseToMavenCentral
                                 """
                             )
                         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,71 +1,28 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id "java-library"
-    id "maven-publish"
-    id "signing"
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("com.vanniktech.maven.publish.base") version "0.29.0"
 }
 
-group = "com.wire"
-version = System.getenv("version")
-
-def Properties properties = new Properties()
-properties.load(project.rootProject.file("local.properties").newDataInputStream())
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            username = properties.getProperty("sonatype.username") ?: System.getenv("SONATYPE_USERNAME")
-            password = properties.getProperty("sonatype.password") ?: System.getenv("SONATYPE_PASSWORD")
-        }
-    }
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    pomFromGradleProperties()
+    signAllPublications()
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            artifact "build/dist/android/avs.aar"
-
-            pom {
-                name.set("wire-avs")
-                description.set("Wire - Audio, Video, and Signaling (AVS)")
-                url.set("https://github.com/wireapp/wire-avs")
-                licenses {
-                    license {
-                        name.set("GPL-3.0")
-                        url.set("https://opensource.org/licenses/GPL-3.0")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("svenwire")
-                        name.set("Sven Jost")
-                        email.set("sven@wire.com")
-                        organization.set("Wire Swiss GmbH")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:git://github.com/wireapp/wire-avs")
-                    developerConnection.set("scm:git:git://github.com/wireapp/wire-avs")
-                    url.set("https://github.com/wireapp/wire-avs")
-                }
-                withXml {
-                    def dependenciesNode = asNode().appendNode('dependencies')
-                    findProject(':android:lib').configurations.implementation.allDependencies.each {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
-                    }
-                }
+afterEvaluate {
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifact "build/dist/android/avs.aar"
             }
         }
     }
-}
-
-signing {
-    def signingKeyFile = properties.getProperty("signingKeyFile") ?: System.getenv("PGP_PRIVATE_KEY_FILE")
-    def signingKey = new File(signingKeyFile).text
-    def signingPassword = properties.getProperty("signingPassword") ?: System.getenv("PGP_PASSPHRASE")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
+    // Allows skipping signing jars published to 'MavenLocal' repository
+    tasks.named("signMavenJavaPublication").configure {
+        if (System.getenv("CI") == null) { // i.e. not in Github Action runner
+            enabled = false
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,16 @@
+# gradle-maven-publish configuration
+GROUP=com.wire
+SONATYPE_HOST=CENTRAL_PORTAL
+SONATYPE_AUTOMATIC_RELEASE=true
+RELEASE_SIGNING_ENABLED=true
+POM_NAME=wire-avs
+POM_DESCRIPTION=Wire - Audio, Video, and Signaling (AVS)
+POM_URL=https://github.com/wireapp/wire-avs
+POM_LICENCE_NAME=GPL-3.0
+POM_LICENCE_URL=https://opensource.org/licenses/GPL-3.0
+POM_LICENSE_DIST=repo
+POM_SCM_URL=https://github.com/wireapp/wire-avs
+POM_SCM_CONNECTION=scm:git:git://github.com/wireapp/wire-avs
+POM_SCM_DEV_CONNECTION=scm:git:git://github.com/wireapp/wire-avs
+POM_DEVELOPER_NAME=Jacob Persson
+POM_DEVELOPER_EMAIL=jacob.persson@wire.com


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Our `com.wire` namespace on Sonatype has been migrated to their new Sonatype Central API and so we need to start publishing there instead.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
