### PR TITLE
feat: reduce resolution switching in chrome

### DIFF
--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -1041,7 +1041,7 @@ function getEncodingParameter(sender: RTCRtpSender, isScreenShare: boolean) {
             //@ts-ignore
             coding.scalabilityMode = 'L1T1'
             coding.active = true
-            coding.scaleResolutionDownBy = 4;
+            coding.scaleResolutionDownBy = 4.0;
             coding.maxBitrate = 250000;
             layerFound = true;
         }
@@ -1049,7 +1049,7 @@ function getEncodingParameter(sender: RTCRtpSender, isScreenShare: boolean) {
             //@ts-ignore
             coding.scalabilityMode = 'L1T1'
 
-            coding.scaleResolutionDownBy = 1;
+            coding.scaleResolutionDownBy = 1.0;
             coding.active = true;
             coding.maxBitrate = 3000000;
             layerFound = true;
@@ -1702,6 +1702,11 @@ function sdpCbrMap(sdp: string): string {
         if (spaces < 3) {
           outline = null;
         }
+      }
+
+      else if (sdpLine.startsWith('a=simulcast:recv l;h') && pc_env !== ENV_FIREFOX) {
+          // add conference attribute for chrome
+          sdpLines.push('a=x-google-flag:conference')
       }
       // reorder rids for firefox
       else if (sdpLine.startsWith('a=simulcast:recv l;h') && pc_env === ENV_FIREFOX) {


### PR DESCRIPTION
# What's new in this PR?

Add the x-conference flag to the video track in the SDP to avoid to much qualityLimitationResolutionChanges evebts in Chrome for simulcast

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
