### PR TITLE
feature: deactivate low resolution for screenshare

### DIFF
--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -1040,9 +1040,9 @@ function getEncodingParameter(sender: RTCRtpSender, isScreenShare: boolean) {
         if(coding.rid === 'l') {
             //@ts-ignore
             coding.scalabilityMode = 'L1T1'
-            coding.active = true
+            coding.active = !isScreenShare
             coding.scaleResolutionDownBy = 2.0;
-            coding.maxBitrate = 250000;
+            coding.maxBitrate = 500000;
             layerFound = true;
         }
         if(coding.rid === 'h') {
@@ -1051,7 +1051,7 @@ function getEncodingParameter(sender: RTCRtpSender, isScreenShare: boolean) {
 
             coding.scaleResolutionDownBy = 1.0;
             coding.active = true;
-            coding.maxBitrate = 3000000;
+            coding.maxBitrate = isScreenShare? 1500000: 3000000;
             layerFound = true;
         }
     });


### PR DESCRIPTION

Deactivate low resolution when doing screen share

----

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
