### PR TITLE
Bugfix/media delay

### DIFF
--- a/include/avs_wcall.h
+++ b/include/avs_wcall.h
@@ -217,11 +217,14 @@ typedef void (wcall_log_h)(int level,
 #define WCALL_AUDIO_STATE_NETWORK_PROBLEM  2 
 
 /* Video receive state */
-#define	WCALL_VIDEO_STATE_STOPPED     0
-#define	WCALL_VIDEO_STATE_STARTED     1
-#define	WCALL_VIDEO_STATE_BAD_CONN    2
-#define	WCALL_VIDEO_STATE_PAUSED      3
-#define	WCALL_VIDEO_STATE_SCREENSHARE 4
+#define	WCALL_VIDEO_STATE_STOPPED      0
+#define	WCALL_VIDEO_STATE_STARTED      1
+#define	WCALL_VIDEO_STATE_BAD_CONN     2
+#define	WCALL_VIDEO_STATE_PAUSED       3
+#define	WCALL_VIDEO_STATE_SCREENSHARE  4
+/* RECONNECTING is only needed in Web to dealing with reconnecting when toggle camera on! */
+/* This is not used inside of AVS */
+#define	WCALL_VIDEO_STATE_RECONNECTING 5
 
 /**
  * Callback used to inform user that received video has started or stopped

--- a/src/ccall/ccall.c
+++ b/src/ccall/ccall.c
@@ -303,8 +303,10 @@ static void set_state(struct ccall* ccall, enum ccall_state state)
 	case CCALL_STATE_CONNSENT:
 		ccall->received_confpart = false;
 		if (!ccall->is_mls_call) {
-			keystore_reset_keys(ccall->keystore);
-			tmr_cancel(&ccall->tmr_rotate_mls);
+			if (ccall->reconnect_attempts == 0) {
+				keystore_reset_keys(ccall->keystore);
+				tmr_cancel(&ccall->tmr_rotate_mls);
+			}
 		}
 		tmr_cancel(&ccall->tmr_rotate_key);
 		tmr_cancel(&ccall->tmr_send_check);

--- a/src/ecall/ecall.c
+++ b/src/ecall/ecall.c
@@ -1593,6 +1593,11 @@ static void channel_estab_handler(struct iflow *iflow, void *arg)
 
 	tmr_cancel(&ecall->dc_tmr);
 
+	if (ecall->oldflow) {
+		IFLOW_CALL(ecall->oldflow, close);
+		ecall->oldflow = NULL;
+	}
+	
 	econn_set_datachan_established(ecall->econn);
 
 	if (ecall->delayed_restart) {
@@ -1908,10 +1913,12 @@ static void rtp_start_handler(struct iflow *iflow,
 			ecall->call_setup_time = now - ecall->ts_started;
 		}
 
+#if 0
 		if (ecall->oldflow) {
 			IFLOW_CALL(ecall->oldflow, close);
 			ecall->oldflow = NULL;
 		}
+#endif
 	}
 }
 
@@ -2735,7 +2742,7 @@ int ecall_media_start(struct ecall *ecall)
 	if (err) {
 		warning("ecall: mediaflow start media failed (%m)\n", err);
 		econn_set_error(ecall->econn, err);
-		goto out;
+		goto out;w
 	}
 */	info("ecall(%p): media started on flow:%p\n", ecall, ecall->flow);
 


### PR DESCRIPTION
----

When switching on the camera, we now wait until the encryption key reaches the client before we remove the old media pipe

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
