### PR TITLE
fix: toggle camera in case peer-to-peer glare delayed  [WPB-17595]

### DIFF
--- a/src/ecall/ecall.c
+++ b/src/ecall/ecall.c
@@ -2588,7 +2588,6 @@ struct econn *ecall_get_econn(const struct ecall *ecall)
 int ecall_set_video_send_state(struct ecall *ecall, enum icall_vstate vstate)
 {
 	int err = 0;
-
 	if (!ecall)
 		return EINVAL;
 
@@ -2605,6 +2604,14 @@ int ecall_set_video_send_state(struct ecall *ecall, enum icall_vstate vstate)
 
 		return 0;
 	}
+
+    enum econn_state conn_current_state = econn_current_state(ecall->econn);
+    if (ecall->conv_type == ICALL_CONV_TYPE_ONEONONE && (ecall->update || conn_current_state == ECONN_UPDATE_RECV)) {
+        info("ecall(%p): set_video_send_state: ignored, already in update state\n", ecall);
+
+        return 0;
+    }
+
 
 	const char *vstate_string;
 	const char *sstate_string;
@@ -2667,7 +2674,7 @@ int ecall_set_video_send_state(struct ecall *ecall, enum icall_vstate vstate)
 		case ECONN_DATACHAN_ESTABLISHED:
 			ecall_restart(ecall, ICALL_CALL_TYPE_VIDEO, false);
 			goto out;
-			
+
 		default:
 			break;
 		}

--- a/src/ecall/ecall.c
+++ b/src/ecall/ecall.c
@@ -1653,6 +1653,16 @@ static void channel_estab_handler(struct iflow *iflow, void *arg)
 		      0,
 		      0,
 		      ecall->icall.arg);
+
+	if (ecall->update_glare) {
+		info("ecall(%p): handle delayed glare %s->%s\n",
+		     ecall,
+		     icall_vstate_name(ecall->vstate),
+		     icall_vstate_name(ecall->glare_vstate));
+		ecall->update_glare = false;
+		err = ecall_set_video_send_state(ecall, ecall->glare_vstate);
+	}
+
 	return;
 
  error:
@@ -2605,12 +2615,13 @@ int ecall_set_video_send_state(struct ecall *ecall, enum icall_vstate vstate)
 		return 0;
 	}
 
-    enum econn_state conn_current_state = econn_current_state(ecall->econn);
-    if (ecall->conv_type == ICALL_CONV_TYPE_ONEONONE && (ecall->update || conn_current_state == ECONN_UPDATE_RECV)) {
-        info("ecall(%p): set_video_send_state: ignored, already in update state\n", ecall);
-
-        return 0;
-    }
+	enum econn_state conn_current_state = econn_current_state(ecall->econn);
+	if (ecall->conv_type == ICALL_CONV_TYPE_ONEONONE && (ecall->update || conn_current_state == ECONN_UPDATE_RECV)) {
+		info("ecall(%p): set_video_send_state: postpone video update state %s, because of glare\n", ecall, icall_vstate_name(ecall->vstate));
+		ecall->update_glare = true;
+		ecall->glare_vstate = vstate;
+		return 0;
+	}
 
 
 	const char *vstate_string;

--- a/src/ecall/ecall.h
+++ b/src/ecall/ecall.h
@@ -114,6 +114,7 @@ struct ecall {
 	struct le ecall_le;
 	enum icall_call_type call_type;
 	enum icall_vstate vstate;
+    enum icall_vstate glare_vstate;
 	struct ecall_conf conf;
 	struct msystem *msys;
 	struct econn *econn;
@@ -153,6 +154,7 @@ struct ecall {
 	bool answered;
 	bool established;
 	bool update;
+    bool update_glare;
 	bool delayed_restart;
 	int32_t call_setup_time;
 	int32_t call_estab_time;


### PR DESCRIPTION
In case of 1:1 calls we delay local camera switch on, when local peer run in glare if he tries to toggle his camera on
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
