### PR TITLE
fix: remove request video optimisation

### DIFF
--- a/src/ccall/ccall.c
+++ b/src/ccall/ccall.c
@@ -1288,21 +1288,22 @@ static int send_confpart_response(struct ccall *ccall)
 	return err;
 }
 
-static bool has_video_for_client(struct ccall *ccall, struct icall_client *cli)
-{
-	bool found = false;
-	struct le *le;
-
-	for(le = ccall->videol.head; !found && le; le = le->next) {
-		struct icall_client *vi = le->data;
-
-		found = streq(vi->userid, cli->userid)
-		     && streq(vi->clientid, cli->clientid)
-		     && vi->quality == cli->quality;
-	}
-
-	return found;
-}
+// @deprecated Right now it's causing more problems, so we're disabling this feature. But we'll reconsider
+//static bool has_video_for_client(struct ccall *ccall, struct icall_client *cli)
+//{
+//	bool found = false;
+//	struct le *le;
+//
+//	for(le = ccall->videol.head; !found && le; le = le->next) {
+//		struct icall_client *vi = le->data;
+//
+//		found = streq(vi->userid, cli->userid)
+//		     && streq(vi->clientid, cli->clientid)
+//		     && vi->quality == cli->quality;
+//	}
+//
+//	return found;
+//}
 
 int  ccall_request_video_streams(struct icall *icall,
 				 struct list *clientl,
@@ -1317,7 +1318,6 @@ int  ccall_request_video_streams(struct icall *icall,
 	struct le *le = NULL;
 	struct mbuf *qb;
 	char *clients_str;
-	bool found = true;
 	int err = 0;
 
 	if (!ccall)
@@ -1325,16 +1325,6 @@ int  ccall_request_video_streams(struct icall *icall,
 
 	if (!clientl || NULL == clientl->head)
 		return EINVAL;
-
-	for(le = clientl->head; found && le; le = le->next) {
-		struct icall_client *cli = le->data;
-
-		found = has_video_for_client(ccall, cli);
-	}
-	if (found) {
-		info("ccall(%p): request_video_streams skipping for identical clients\n", ccall);
-		return 0;
-	}
 
 	self = userlist_get_self(ccall->userl);
 	if (!self)


### PR DESCRIPTION
----
# What's new in this PR?

We've optimized the number of video requests. Unfortunately, it's blocking too many intentional requests, so we're removing the optimization. It's now up to Client to implement this optimization.

