### PR TITLE
Use connectionChange event instead of iceConenctionChange

### DIFF
--- a/src/jsflow/jsflow.c
+++ b/src/jsflow/jsflow.c
@@ -1616,13 +1616,6 @@ void pc_connection_handler(int self, const char *state)
 				true, true, flow->iflow.arg);
 		}
 	}
-	else if (streq(state, "disconnected")) {
-		info("flow(%p): connection_handler: disconnected, "
-		     "starting disconnect timer\n", flow);
-
-		tmr_start(&flow->tmr_disconnect, DISCONNECT_TIMEOUT,
-			  disconnect_timeout_handler, flow);
-	}
 	else if (streq(state, "failed")) {
 		if (tmr_isrunning(&flow->tmr_disconnect))
 			tmr_cancel(&flow->tmr_disconnect);

--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -1338,7 +1338,7 @@ function connectionHandler(pc: PeerConnection) {
   if (!rtc) {
     return;
   }
-  const state = rtc.iceConnectionState;
+  const state = rtc.connectionState;
 
   pc_log(LOG_LEVEL_INFO, `connectionHandler state: ${state}`);
 
@@ -1468,7 +1468,7 @@ function pc_Create(hnd: number, privacy: number, conv_type: number) {
 
   pc.rtc = rtc;
   rtc.onicegatheringstatechange = () => gatheringHandler(pc);
-  rtc.oniceconnectionstatechange = () => connectionHandler(pc);
+  rtc.onconnectionstatechange = () => connectionHandler(pc);
   rtc.onicecandidate = (event) => candidateHandler(pc, event.candidate);
   rtc.onsignalingstatechange = event => signallingHandler(pc);
   rtc.ondatachannel = event => dataChannelHandler(pc, event);


### PR DESCRIPTION
This PR moves the connection monitoring from iceConnectionChange to connectionChange, and relies on webrtc to inform about connection failures.
