### PR TITLE
API changes for Wire meetings

### DIFF
--- a/docs/api/api_changes_10.2.txt
+++ b/docs/api/api_changes_10.2.txt
@@ -1,0 +1,28 @@
+Changes introduced in AVS 10.2
+==============================
+
+Chagned the API for:
+  - wcall_recv_msg
+  - wcall_start
+
+Both of these now contain a boolean meeting parameter that should be set depending
+on if the conversation is a Wire meeting or not.
+The wcall_start meeting parameter is not strictly needed, but has been added for any
+future possibilities to improve the Wire meeting experience.
+
+int  wcall_recv_msg(WUSER_HANDLE wuser, const uint8_t *buf, size_t len,
+		    uint32_t curr_time, /* timestamp in seconds */
+		    uint32_t msg_time,  /* timestamp in seconds */
+		    const char *convid,
+		    const char *userid,
+		    const char *clientid,
+		    int conv_type,
+		    int meeting) <-- new parameter
+
+
+int wcall_start(WUSER_HANDLE wuser, const char *convid,
+		int call_type, /*WCALL_CALL_TYPE...*/
+		int conv_type, /*WCALL_CONV_TYPE...*/
+		int audio_cbr, /*bool*/
+                int meeting /*bool*/) <-- new parameter
+		

--- a/include/avs_ccall.h
+++ b/include/avs_ccall.h
@@ -37,7 +37,8 @@ int ccall_alloc(struct ccall **ccallp,
 		const char *convid,
 		const char *userid_self,
 		const char *clientid,
-		bool is_mls_call);
+		bool is_mls_call,
+		bool meeting);
 
 struct icall *ccall_get_icall(struct ccall* ccall);
 

--- a/include/avs_wcall.h
+++ b/include/avs_wcall.h
@@ -347,7 +347,8 @@ int wcall_set_background(WUSER_HANDLE wuser, int background);
 int wcall_start(WUSER_HANDLE wuser, const char *convid,
 		int call_type, /*WCALL_CALL_TYPE...*/
 		int conv_type, /*WCALL_CONV_TYPE...*/
-		int audio_cbr /*bool*/);
+		int audio_cbr, /*bool*/
+                int meeting /*bool*/);
 
 /* Returns 0 if successfull
  * Set call_type from defines above.
@@ -379,7 +380,8 @@ int  wcall_recv_msg(WUSER_HANDLE wuser, const uint8_t *buf, size_t len,
 		    const char *convid,
 		    const char *userid,
 		    const char *clientid,
-		    int conv_type);
+		    int conv_type,
+		    int meeting);
 
 /* End the call in the conversation associated to
  * the conversation id in the convid parameter.

--- a/src/ccall/ccall.c
+++ b/src/ccall/ccall.c
@@ -2553,7 +2553,8 @@ int ccall_alloc(struct ccall **ccallp,
 		const char *convid,
 		const char *userid_self,
 		const char *clientid,
-		bool is_mls_call)
+		bool is_mls_call,
+		bool meeting)
 {
 	char convid_anon[ANON_ID_LEN];
 	char userid_anon[ANON_ID_LEN];
@@ -2616,6 +2617,7 @@ int ccall_alloc(struct ccall **ccallp,
 	ccall->state = CCALL_STATE_IDLE;
 	ccall->stop_ringing_reason = CCALL_STOP_RINGING_NONE;
 	ccall->is_mls_call = is_mls_call;
+	ccall->meeting = meeting;
 	ccall->metrics.conv_type = is_mls_call ? ICALL_CONV_TYPE_CONFERENCE_MLS : ICALL_CONV_TYPE_CONFERENCE;
 
 	tmr_init(&ccall->tmr_connect);
@@ -3407,6 +3409,9 @@ static int ccall_handle_confstart_check(struct ccall* ccall,
 				should_ring = false;
 			}
 
+			if (ccall->meeting) {
+			         should_ring = false;
+			}
 			ccall->is_ringing = should_ring;
 			set_state(ccall, CCALL_STATE_INCOMING);
 

--- a/src/ccall/ccall.h
+++ b/src/ccall/ccall.h
@@ -108,6 +108,7 @@ struct ccall {
 	struct keystore *keystore;
 
 	enum icall_call_type call_type;
+        bool meeting;
 	enum icall_vstate vstate;
 
 	bool someone_joined;

--- a/src/wcall/wcall.h
+++ b/src/wcall/wcall.h
@@ -14,7 +14,8 @@ struct wcall_marshal *wcall_get_marshal(struct calling_instance *inst);
 
 struct wcall *wcall_lookup(struct calling_instance *inst, const char *convid);
 int  wcall_add(struct calling_instance *inst,
-	       struct wcall **wcallp, const char *convid, int conv_type);
+	       struct wcall **wcallp, const char *convid,
+	       int conv_type, bool meeting);
 void wcall_mcat_changed(struct calling_instance *inst,
 			enum mediamgr_state state);
 void wcall_audio_route_changed(struct calling_instance *inst,
@@ -37,7 +38,8 @@ void wcall_i_recv_msg(struct calling_instance *inst,
 		      const char *convid,
 		      const char *userid,
 		      const char *clientid,
-		      int conv_type);
+		      int conv_type,
+		      bool meeting);
 void wcall_i_config_update(struct calling_instance *inst,
 			   int err, const char *json_str);
 void wcall_i_resp(struct calling_instance *inst,
@@ -48,7 +50,8 @@ void wcall_i_sft_resp(struct calling_instance *inst,
 		      void *arg);
 int  wcall_i_start(struct wcall *wcall,
 		   int is_video_call, int group,
-		   int audio_cbr);
+		   int audio_cbr,
+		   bool meeting);
 int wcall_i_answer(struct wcall *wcall,
 		   int call_type, int audio_cbr);
 int  wcall_i_reject(struct wcall *wcall);

--- a/tools/zcall/calling3.c
+++ b/tools/zcall/calling3.c
@@ -1029,7 +1029,7 @@ void calling3_recv_msg(const char *convid,
 	int conv_type = engine_conv2type(conv);
 	err = wcall_recv_msg(calling3.wuser, (uint8_t *)data, len,
 		       now.sec, timestamp->sec,
-		       convid, from_userid, from_clientid, conv_type);
+			     convid, from_userid, from_clientid, conv_type, false);
 
 	if (err == WCALL_ERROR_UNKNOWN_PROTOCOL) {
 		warning("calling3: recv_msg: unknown protocol, please update your client!\n");
@@ -1266,7 +1266,8 @@ int calling3_start(struct engine_conv *conv)
 
 	ret = wcall_start(calling3.wuser, conv->id,
 			  call_type, conv_type,
-			  zcall_audio_cbr);
+			  zcall_audio_cbr,
+			  false);
 	if (ret < 0) {
 		warning("start: wcall_start failed\n");
 		goto out;


### PR DESCRIPTION
These are the API changes as required for Wire meetings, so as to support not ringing on the incoming call.