### PR TITLE
fix: increase the SDP byte size from 16KiB to 24KiB [WPB-19903]

### DIFF
--- a/src/ecall/ecall.c
+++ b/src/ecall/ecall.c
@@ -43,7 +43,7 @@
 #include "ecall.h"
 
 
-#define SDP_MAX_LEN 16384
+#define SDP_MAX_LEN 24576 // max 24 KiB
 #define ECALL_MAGIC 0xeca1100f
 
 #define TIMEOUT_DC_CLOSE     10000


### PR DESCRIPTION
# What's new in this PR?

The Rust SFT enforces more Answer session description data in case of a connection update.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
