### PR TITLE
WPB-27891: fix: resolve original caller for call-end "called" message

### DIFF
--- a/src/wcall/event.c
+++ b/src/wcall/event.c
@@ -355,9 +355,18 @@ int  wcall_event_process(WUSER_HANDLE wuser,
 				ev->reason = WCALL_REASON_NORMAL;
 			}
 			else {
+				/* No SETUP was seen for this call, so the envelope
+				 * sender of CONF_END may not be the caller. Prefer
+				 * the originator declared in the payload
+				 * (src_userid) when present; fall back to the
+				 * envelope sender otherwise. */
+				const char *caller_userid =
+					str_isset(msg->src_userid) ? msg->src_userid : userid;
+				const char *caller_clientid =
+					str_isset(msg->src_clientid) ? msg->src_clientid : clientid;
 				queue_event(inst,
 					    convid,
-					    userid, clientid,
+					    caller_userid, caller_clientid,
 					    msg->time,
 					    conv_type,
 					    CALL_EVENT_STATE_CLOSED,

--- a/src/wcall/wcall.c
+++ b/src/wcall/wcall.c
@@ -204,6 +204,14 @@ struct wcall {
 
 	int state; /* wcall state */
 	bool disable_audio;
+
+	/* Original caller captured from the incoming SETUP/CONF_START
+	 * (server-authenticated envelope sender). Reported on close/missed
+	 * so call-end surfaces attribute to the caller rather than the
+	 * sender of the end/missed-trigger message. NULL for outgoing
+	 * calls, where self is the caller (existing fallback applies). */
+	char *orig_userid;
+	char *orig_clientid;
 	
 	struct le le;
 };
@@ -551,13 +559,20 @@ static void icall_start_handler(struct icall *icall,
 	struct calling_instance *inst = wcall ? wcall->inst : NULL;
 	int ct = WCALL_CONV_TYPE_ONEONONE;
 
-	(void)clientid_sender;
 
 	if (!WCALL_VALID(wcall)) {
 		warning("wcall(%p): icall_start_handler: invalid wcall "
 			"inst=%p\n", wcall, inst);
 		return;
 	}
+	/* Capture the original caller for the lifetime of this call, so
+	 * close/missed callbacks report the caller instead of the sender
+	 * of the close-inducing message. Set once; the originator is
+	 * invariant for a given call. */
+	if (!wcall->orig_userid && userid_sender)
+		str_dup(&wcall->orig_userid, userid_sender);
+	if (!wcall->orig_clientid && clientid_sender)
+		str_dup(&wcall->orig_clientid, clientid_sender);
 
 	set_state(wcall, WCALL_STATE_INCOMING);
 
@@ -1212,7 +1227,13 @@ static void icall_close_handler(struct icall *icall, int err,
 		set_state(wcall, WCALL_STATE_TERM_REMOTE);
 	}
 
-	if (!userid) {
+	if (wcall->orig_userid) {
+		/* Report the original caller captured at ring time, not the
+		 * sender of the close-inducing message. */
+		userid = wcall->orig_userid;
+		clientid = wcall->orig_clientid;
+	}
+	else if (!userid) {
 		userid = inst->userid;
 	}
 	set_state(wcall, WCALL_STATE_NONE);
@@ -1327,7 +1348,9 @@ static void icall_leave_handler(struct icall* icall, int reason, uint32_t msg_ti
 		     wcall_reason_name(reason));
 
 		inst->closeh(wreason, wcall->convid, msg_time,
-			     inst->userid, inst->clientid, inst->arg);
+			     wcall->orig_userid ? wcall->orig_userid : inst->userid,
+			     wcall->orig_clientid ? wcall->orig_clientid : inst->clientid,
+			     inst->arg);
 		info(APITAG "wcall(%p): icall_leave_handler: "
 		     "closeh took %llu ms\n",
 		     wcall, tmr_jiffies() - now);
@@ -1639,6 +1662,8 @@ static void destructor(void *arg)
 
 	mem_deref(wcall->icall);
 	mem_deref(wcall->convid);
+	mem_deref(wcall->orig_userid);
+	mem_deref(wcall->orig_clientid);
 
 	info("wcall(%p): dtor -- done\n", wcall);
 }
@@ -3535,8 +3560,10 @@ int wcall_i_reject(struct wcall *wcall)
 			     wcall_reason_name(reason));
 
 			inst->closeh(reason, wcall->convid,
-				ECONN_MESSAGE_TIME_UNKNOWN, inst->userid,
-				inst->clientid, inst->arg);
+			            ECONN_MESSAGE_TIME_UNKNOWN,
+			            wcall->orig_userid ? wcall->orig_userid : inst->userid,
+			            wcall->orig_clientid ? wcall->orig_clientid : inst->clientid,
+			            inst->arg);
 			info(APITAG "wcall(%p): wcall_reject: closeh took %llu ms\n",
 			     wcall, tmr_jiffies() - now);
 		}


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-27891

Call-end surfaces attributed the message to whoever sent the end/missed-trigger message rather than the original caller, because AVS reported the OTR envelope sender of whichever message triggered each callback (incomingh -> SETUP sender = caller, but closeh/ missedh -> end-message sender, usually not the caller).

Persist the SETUP/CONF_START envelope sender (the server-authenticated original caller) for the call lifetime and report it on the close/leave/missed callbacks instead of the end-message sender.

In the NSE event path, a SETUP-triggered event uses the authenticated envelope sender (which IS the caller); the self-declared src_userid from the decoded econn_message is used only for the CONF_END->CLOSED fallback, where no SETUP was seen and there is no better signal, falling back to the envelope sender when src_userid is absent.

Outgoing calls keep the existing self fallback (no SETUP is seen, so self is the caller).

It's LLM-generated, please, review it carefully.
