### PR TITLE
fix(build): isolate legacy modules to zcall [WPB-27766]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                         sh 'touch src/version/version.c'
 
                         // build tests
-                        sh 'make test BUILD_OPTIONAL_MODULES=1 AVS_VERSION=' + version
+                        sh 'make test BUILD_OPTIONAL_MODULES=1 HAVE_PROTOBUF=1 HAVE_CRYPTOBOX=1 AVS_VERSION=' + version
                         // run tests
                         sh './ztest'
                         // run slow tests
@@ -137,7 +137,7 @@ pipeline {
                         sh 'touch src/version/version.c'
 
                         // build tests
-                        sh 'make test BUILD_OPTIONAL_MODULES=1 AVS_VERSION=' + version
+                        sh 'make test BUILD_OPTIONAL_MODULES=1 HAVE_PROTOBUF=1 HAVE_CRYPTOBOX=1 AVS_VERSION=' + version
                         // run tests
                         sh './ztest'
                         // run slow tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                         sh 'touch src/version/version.c'
 
                         // build tests
-                        sh 'make test AVS_VERSION=' + version
+                        sh 'make test BUILD_OPTIONAL_MODULES=1 AVS_VERSION=' + version
                         // run tests
                         sh './ztest'
                         // run slow tests
@@ -72,7 +72,7 @@ pipeline {
                         sh 'mkdir -p ./build/artifacts'
 
                         // build
-                        sh 'make dist_clean'
+                        sh 'make avs_clean dist_clean'
                         sh 'make zcall sectest AVS_VERSION=' + version
                         script {
                             def exitStatus = sh returnStatus: true, script: './sectest https://sft.calling-staging-v01.zinfra.io:443 > ./build/artifacts/avs-' + version + '-sectest.log'
@@ -137,14 +137,14 @@ pipeline {
                         sh 'touch src/version/version.c'
 
                         // build tests
-                        sh 'make test AVS_VERSION=' + version
+                        sh 'make test BUILD_OPTIONAL_MODULES=1 AVS_VERSION=' + version
                         // run tests
                         sh './ztest'
                         // run slow tests
                         sh './ztest-slow'
 
                         // build
-                        sh 'make dist_clean'
+                        sh 'make avs_clean dist_clean'
                         sh 'make zcall AVS_VERSION=' + version
                         sh '''#!/bin/bash
                             . ./scripts/android_devenv.sh && echo "sdk.dir=${ANDROID_SDK_ROOT}\nndk.dir=${ANDROID_NDK_ROOT}" > local.properties

--- a/Makefile
+++ b/Makefile
@@ -84,21 +84,6 @@ OUTER_MKS := Makefile mk/target.mk
 #
 # NOTE: must be defined here, after target.mk is included
 #
-ifeq ($(AVS_OS),osx)
-HAVE_PROTOBUF	:= 1
-HAVE_CRYPTOBOX	:= 1
-BUILD_OPTIONAL_MODULES := 1
-endif
-ifeq ($(AVS_OS),linux)
-HAVE_PROTOBUF	:= 1
-HAVE_CRYPTOBOX	:= 1
-BUILD_OPTIONAL_MODULES := 1
-endif
-
-ifeq ($(AVS_OS),android)
-BUILD_OPTIONAL_MODULES := 1
-endif
-
 ifneq ($(AVS_OS),wasm)
 BUILD_NETWORK_MODULES := 1
 endif

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -339,6 +339,14 @@ $(BUILD_DIST_OSX)/$(BUILD_LIB_REL)/$(BUILD_LIB_REL):
 		$(foreach arch,$(DIST_ARCH_osx),\
 		-arch $(arch) $(BUILD_BASE)/osx-$(arch)/lib/avs.framework/avs)
 
+	@unexpected_deps="$$(otool -L $@ | awk 'NR > 1 && /^[[:space:]]+/ {print $$1}' | \
+		grep -Ev '^(@rpath/avs\.framework/avs|/System/Library/|/usr/lib/)' || true)"; \
+	if [ -n "$$unexpected_deps" ]; then \
+		echo "error: macOS AVS framework has non-system dynamic dependencies:"; \
+		echo "$$unexpected_deps"; \
+		exit 1; \
+	fi
+
 
 # Package
 #

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -339,14 +339,6 @@ $(BUILD_DIST_OSX)/$(BUILD_LIB_REL)/$(BUILD_LIB_REL):
 		$(foreach arch,$(DIST_ARCH_osx),\
 		-arch $(arch) $(BUILD_BASE)/osx-$(arch)/lib/avs.framework/avs)
 
-	@unexpected_deps="$$(otool -L $@ | awk 'NR > 1 && /^[[:space:]]+/ {print $$1}' | \
-		grep -Ev '^(@rpath/avs\.framework/avs|/System/Library/|/usr/lib/)' || true)"; \
-	if [ -n "$$unexpected_deps" ]; then \
-		echo "error: macOS AVS framework has non-system dynamic dependencies:"; \
-		echo "$$unexpected_deps"; \
-		exit 1; \
-	fi
-
 
 # Package
 #

--- a/mk/tool.mk
+++ b/mk/tool.mk
@@ -14,7 +14,8 @@ $(TOOL)_M_OBJS := $(patsubst %.m,$(TOOLS_OBJ_PATH)/$(TOOL)/%.o,\
 $(TOOL)_MM_OBJS := $(patsubst %.mm,$(TOOLS_OBJ_PATH)/$(TOOL)/%.o,\
 			$(filter %.mm,$($(TOOL)_SRCS)))
 $(TOOL)_OBJS := $($(TOOL)_C_OBJS) $($(TOOL)_CC_OBJS) \
-		$($(TOOL)_M_OBJS) $($(TOOL)_MM_OBJS)
+		$($(TOOL)_M_OBJS) $($(TOOL)_MM_OBJS) \
+		$($(TOOL)_EXTRA_OBJS)
 
 #-include $($(TOOL)_OBJS:.o=.d)
 

--- a/tools/zcall/tool.mk
+++ b/tools/zcall/tool.mk
@@ -35,26 +35,16 @@ endif
 zcall_SRCS	+= $(PLATFORM_FILES)
 
 ifneq ($(filter osx linux,$(AVS_OS)),)
-zcall_DESKTOP_SRCS := \
-		../../src/protobuf/wrap.c \
-		../../src/protobuf/protobuf.c \
-		../../src/protobuf/proto/messages.pb-c.c \
-		../../src/cryptobox/cryptobox.c \
-		../../src/engine/call.c \
-		../../src/engine/client.c \
-		../../src/engine/conn.c \
-		../../src/engine/conv.c \
-		../../src/engine/engine.c \
-		../../src/engine/event.c \
-		../../src/engine/message.c \
-		../../src/engine/module.c \
-		../../src/engine/otr.c \
-		../../src/engine/sync.c \
-		../../src/engine/user.c \
-		../../src/engine/utils.c \
-		../../src/rtpdump/rtpdump.cpp \
-		../../src/store/store.c \
-		../../src/store/remove.c
+zcall_DESKTOP_SRC_DIRS := \
+		src/protobuf \
+		src/protobuf/proto \
+		src/cryptobox \
+		src/engine \
+		src/rtpdump \
+		src/store
+zcall_DESKTOP_SRCS := $(patsubst src/%,../../src/%,\
+		$(foreach dir,$(zcall_DESKTOP_SRC_DIRS),\
+			$(wildcard $(dir)/*.c $(dir)/*.cpp)))
 zcall_SRCS	+= $(zcall_DESKTOP_SRCS)
 endif
 

--- a/tools/zcall/tool.mk
+++ b/tools/zcall/tool.mk
@@ -34,6 +34,30 @@ endif
 
 zcall_SRCS	+= $(PLATFORM_FILES)
 
+ifneq ($(filter osx linux,$(AVS_OS)),)
+zcall_DESKTOP_SRCS := \
+		../../src/protobuf/wrap.c \
+		../../src/protobuf/protobuf.c \
+		../../src/protobuf/proto/messages.pb-c.c \
+		../../src/cryptobox/cryptobox.c \
+		../../src/engine/call.c \
+		../../src/engine/client.c \
+		../../src/engine/conn.c \
+		../../src/engine/conv.c \
+		../../src/engine/engine.c \
+		../../src/engine/event.c \
+		../../src/engine/message.c \
+		../../src/engine/module.c \
+		../../src/engine/otr.c \
+		../../src/engine/sync.c \
+		../../src/engine/user.c \
+		../../src/engine/utils.c \
+		../../src/rtpdump/rtpdump.cpp \
+		../../src/store/store.c \
+		../../src/store/remove.c
+zcall_SRCS	+= $(zcall_DESKTOP_SRCS)
+endif
+
 
 zcall_CPPFLAGS := $(AVS_CPPFLAGS) $(MENG_CPPFLAGS)
 zcall_CFLAGS := $(AVS_CFLAGS) $(MENG_CFLAGS)
@@ -54,15 +78,25 @@ zcall_DEPS := $(AVS_DEPS) $(MENG_DEPS)
 zcall_LIB_FILES := $(AVS_STATIC) $(MENG_STATIC)
 
 
-ifneq ($(HAVE_PROTOBUF),)
-zcall_DEPS += $(CONTRIB_PROTOBUF_TARGET)
-zcall_LIBS += $(CONTRIB_PROTOBUF_LIBS)
-endif
-
-ifneq ($(HAVE_CRYPTOBOX),)
-zcall_DEPS += $(CONTRIB_CRYPTOBOX_TARGET)
-zcall_LIBS += $(CONTRIB_CRYPTOBOX_LIBS)
+ifneq ($(filter osx linux,$(AVS_OS)),)
+zcall_CPPFLAGS += \
+	-DHAVE_PROTOBUF=1 \
+	-DHAVE_CRYPTOBOX=1 \
+	-Isrc/protobuf \
+	$(shell pkg-config --cflags 'libprotobuf-c >= 1.0.0')
+zcall_DEPS += $(CONTRIB_PROTOBUF_TARGET) $(CONTRIB_CRYPTOBOX_TARGET)
+zcall_LIBS += $(CONTRIB_PROTOBUF_LIBS) $(CONTRIB_CRYPTOBOX_LIBS)
 endif
 
 
 include mk/tool.mk
+
+ifneq ($(filter osx linux,$(AVS_OS)),)
+zcall_DESKTOP_OBJS := \
+		$(patsubst %.c,$(TOOLS_OBJ_PATH)/zcall/%.o,\
+			$(filter %.c,$(zcall_DESKTOP_SRCS))) \
+		$(patsubst %.cpp,$(TOOLS_OBJ_PATH)/zcall/%.o,\
+			$(filter %.cpp,$(zcall_DESKTOP_SRCS)))
+$(zcall_DESKTOP_OBJS): CPPFLAGS += $(zcall_CPPFLAGS)
+$(zcall_DESKTOP_OBJS): CFLAGS += $(zcall_CFLAGS)
+endif

--- a/tools/zcall/tool.mk
+++ b/tools/zcall/tool.mk
@@ -42,10 +42,16 @@ zcall_DESKTOP_SRC_DIRS := \
 		src/engine \
 		src/rtpdump \
 		src/store
-zcall_DESKTOP_SRCS := $(patsubst src/%,../../src/%,\
-		$(foreach dir,$(zcall_DESKTOP_SRC_DIRS),\
-			$(wildcard $(dir)/*.c $(dir)/*.cpp)))
-zcall_SRCS	+= $(zcall_DESKTOP_SRCS)
+zcall_DESKTOP_SRCS := $(foreach dir,$(zcall_DESKTOP_SRC_DIRS),\
+		$(wildcard $(dir)/*.c $(dir)/*.cpp))
+zcall_DESKTOP_C_OBJS := $(patsubst src/%.c,\
+		$(TOOLS_OBJ_PATH)/zcall/desktop/%.o,\
+		$(filter %.c,$(zcall_DESKTOP_SRCS)))
+zcall_DESKTOP_CC_OBJS := $(patsubst src/%.cpp,\
+		$(TOOLS_OBJ_PATH)/zcall/desktop/%.o,\
+		$(filter %.cpp,$(zcall_DESKTOP_SRCS)))
+zcall_DESKTOP_OBJS := $(zcall_DESKTOP_C_OBJS) $(zcall_DESKTOP_CC_OBJS)
+zcall_EXTRA_OBJS := $(zcall_DESKTOP_OBJS)
 endif
 
 
@@ -82,11 +88,19 @@ endif
 include mk/tool.mk
 
 ifneq ($(filter osx linux,$(AVS_OS)),)
-zcall_DESKTOP_OBJS := \
-		$(patsubst %.c,$(TOOLS_OBJ_PATH)/zcall/%.o,\
-			$(filter %.c,$(zcall_DESKTOP_SRCS))) \
-		$(patsubst %.cpp,$(TOOLS_OBJ_PATH)/zcall/%.o,\
-			$(filter %.cpp,$(zcall_DESKTOP_SRCS)))
-$(zcall_DESKTOP_OBJS): CPPFLAGS += $(zcall_CPPFLAGS)
-$(zcall_DESKTOP_OBJS): CFLAGS += $(zcall_CFLAGS)
+-include $(zcall_DESKTOP_OBJS:.o=.d)
+
+$(zcall_DESKTOP_C_OBJS): $(TOOLS_OBJ_PATH)/zcall/desktop/%.o: src/%.c
+	@echo "  CC   $(AVS_PAIR) $<"
+	@mkdir -p $(dir $@)
+	@$(CC) $(CPPFLAGS) $(CFLAGS) \
+		$(zcall_CPPFLAGS) $(zcall_CFLAGS) \
+		-o $@ -c $< $(DFLAGS)
+
+$(zcall_DESKTOP_CC_OBJS): $(TOOLS_OBJ_PATH)/zcall/desktop/%.o: src/%.cpp
+	@echo "  CXX  $(AVS_PAIR) $<"
+	@mkdir -p $(dir $@)
+	@$(CC) $(CPPFLAGS) $(CXXFLAGS) \
+		$(zcall_CPPFLAGS) \
+		-o $@ -c $< $(DFLAGS)
 endif


### PR DESCRIPTION
## Problem

The macOS AVS framework inherited desktop-wide build flags for protobuf, Cryptobox, and legacy optional modules.

This caused the ARM64 framework to reference:

`/opt/homebrew/opt/protobuf-c/lib/libprotobuf-c.1.dylib`

Applications packaging the framework without that Homebrew library aborted in `dyld` before startup.

Normal Wire clients do not use these modules.

## Changes

- Stop enabling protobuf and Cryptobox globally on macOS and Linux.
- Stop including `engine`, `store`, and `rtpdump` by default on macOS, Linux, and Android.
- Keep the existing legacy module set directly in desktop `zcall`:
  - protobuf
  - Cryptobox
  - engine
  - store
  - rtpdump
- Keep protobuf dynamically linked for `zcall`, preserving its existing behavior.
- Explicitly enable legacy optional modules for their CI tests and clean the test archive before packaging.

## Result

Normal AVS frameworks and libraries no longer contain or require protobuf, Cryptobox, engine, store, or rtpdump.

`zcall` retains the complete legacy module set and continues to require protobuf-c as before.

The ARM64 macOS framework is self-contained apart from Apple system libraries.