### PR TITLE
fix(android): restore optional modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ OUTER_MKS := Makefile mk/target.mk
 #
 # NOTE: must be defined here, after target.mk is included
 #
+ifeq ($(AVS_OS),android)
+BUILD_OPTIONAL_MODULES := 1
+endif
+
 ifneq ($(AVS_OS),wasm)
 BUILD_NETWORK_MODULES := 1
 endif


### PR DESCRIPTION
## Summary

- Restore `BUILD_OPTIONAL_MODULES` by default for Android builds.
- Keep the legacy engine, RTP dump, and store sources linked into Android AVS.
- Leave Linux, macOS, iOS, and Wasm defaults unchanged.

## Problem

Android still compiles `rest/cookie.c`, which calls `store_user_open` and the `sobject_read_*` and `sobject_write_*` helpers. Removing the Android optional-module default stopped compiling the store implementation, so the Android NDK linker aborted while producing `libavs.so`.

### Reproduction

1. Build the Android distribution from `release-10.4` after the optional-module defaults were removed.
2. Observe the ARMv7 `libavs.so` link fail with undefined store and serialized-object symbols referenced by `rest/cookie.c`.

## Fix

Restore the previous Android-only optional-module default. This brings the store implementation back into Android `libavscore.a`, satisfying the REST cookie dependencies without re-enabling protobuf or cryptobox for normal clients.

## Impact

Android distribution builds link successfully again. Other platform defaults and the existing zcall isolation remain unchanged.

## Validation

- The Android ARMv7 distribution builds and packages an AAR successfully.
- The resulting `libavs.so` defines `store_user_open` and the required `sobject_read_*` and `sobject_write_*` symbols.
