### PR TITLE
fix: crash on Android when enabling video before answering group call [WPB-27936]

### DIFF
--- a/src/peerflow/capture_source.cpp
+++ b/src/peerflow/capture_source.cpp
@@ -77,6 +77,9 @@ CaptureSource::CaptureSource()
 
 CaptureSource::~CaptureSource()
 {
+	if (g_cap == this)
+		g_cap = NULL;
+
 	lock_write_get(_lock);
 	list_flush(&_streaml);
 	lock_rel(_lock);
@@ -357,9 +360,11 @@ extern "C" {
 
 void capture_source_handle_frame(struct avs_vidframe *frame)
 {
+	if (!wire::g_cap)
+		return;
+
 	wire::g_cap->HandleFrame(frame);
 }
 
 };
-
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The Android app crashes during an incoming group call when the user enables the camera before answering.
This reproduces with AVS 10.5.3, but not with AVS 10.4.28.
The crash does not happen for incoming 1:1 calls, and after enabling pre-answer video in a 1:1 call once, group-call preview also starts working.

### Causes (Optional)

In AVS 10.4.28, `capture_source_handle_frame()` used `CaptureSource::GetInstance()->HandleFrame(frame)`, so `CaptureSource` was created lazily if missing. In AVS 10.5.3, this changed to directly dereference `wire::g_cap`. During cold group-call preview, `wire::g_cap` can still be NULL, so `wire::g_cap->HandleFrame(frame)` crashes.
Incoming 1:1 video preview usually initializes the peerflow/capture pipeline earlier, so `CaptureSource` already exists by the time camera frames are processed. Group-call preview can receive camera frames before that initialization path has run. After enabling pre-answer video in a 1:1 call once, group-call preview also starts working because `CaptureSource` has already been initialized globally.

### Solutions

Drop early camera frames until `CaptureSource` exists.
Clear g_cap when the current `CaptureSource` is destroyed, preventing stale-pointer access after shutdown.

### Testing

#### How to Test

Receive incoming group call on Android app and try to enable video before answering that call.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
