### PR TITLE
Ensure to cancel and deactivate stats when peerflow is closed

### DIFF
--- a/src/peerflow/peerflow.cpp
+++ b/src/peerflow/peerflow.cpp
@@ -3175,6 +3175,8 @@ void peerflow_close(struct iflow *iflow)
 	if (!pf)
 		return;
 
+	tmr_cancel(&pf->tmr_stats);
+	pf->netStatsCb->setActive(false);
 	if (pf->peerConn) {
 		pf->peerConn->Close();
 		debug("pf(%p): close: peerConn=%p closed\n",


### PR DESCRIPTION
In some rare cases when peerflow is closed, the stats collection would still be running.
Make sure that we stop it.