### PR TITLE
wcall: revert to reject if end is called in incoming state fixes WPB-…

### DIFF
--- a/src/wcall/wcall.c
+++ b/src/wcall/wcall.c
@@ -3447,10 +3447,16 @@ static void wcall_end_internal(struct wcall *wcall)
 		return;
 	}
 
+	if (wcall->state == WCALL_STATE_INCOMING) {
+		info("wcall(%p): end: cannot end in incoming state. Rejecting instead\n", wcall);
+		wcall_i_reject(wcall);
+		return; 
+	}
+
 	if (wcall->state != WCALL_STATE_TERM_REMOTE)
 		set_state(wcall, WCALL_STATE_TERM_LOCAL);
 	ICALL_CALL(wcall->icall, end);
-
+	
 	wcall->disable_audio = true;
 	if (!wcall_has_calls()) {
 		if (wcall->inst->mm) {


### PR DESCRIPTION
This PR fixes a situation if wcall_end is called, and no underlying ecall object has been created by ccall, this would wait for a close_handler from ecall that never happens because it has no ecall associated with it.
Reverting to a reject instead fixes the issue, which is really what should have been called in the first place, but AVS should be redundant to this.