### PR TITLE
fix: filter webrtc stats priority json attribute

### DIFF
--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -2614,7 +2614,8 @@ function pc_GetLocalStats(hnd: number) {
           }
         }
 
-        report += JSON.stringify(stat);
+        // Ignore `priority` as browsers may report values exceeding the AVS JSON decoder range.
+        report += JSON.stringify(stat, (key, value) => key === 'priority' ? undefined : value);
         report += ',';
       })
       // remove tailing ',' if any


### PR DESCRIPTION
# What's new in this PR?

Fix WebRTC stats parsing for large browser priority values

Browsers may report WebRTC stats containing priority values that exceed the numeric range supported by the AVS JSON decoder.

Since priority is currently not used by AVS, filter this field while serializing the WebRTC stats in the browser before passing the report to AVS.

This avoids changing the generic re JSON decoder and prevents otherwise valid stats reports from failing to parse due to an unused field.


##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
