### PR TITLE
fix: race condition on cleanup user in network quality test

### DIFF
--- a/src/peerflow/peerflow.cpp
+++ b/src/peerflow/peerflow.cpp
@@ -484,7 +484,7 @@ static void send_close(struct peerflow *pf, int err)
 	
 	md = (struct mq_data *)mem_zalloc(sizeof(*md), md_destructor);
 	if (!md) {
-		warning("pf(%p): could not alloc md\n");
+		warning("pf(%p): could not alloc md\n", pf);
 		return;
 	}
 	md->id = MQ_PC_CLOSE;
@@ -1312,8 +1312,7 @@ public:
 
 			isdp = pf_->peerConn->local_description();
 			if (!isdp) {
-				warning("pf(%p): ice gathering "
-					"no local SDP\n", pf_);
+				warning("pf(%p): ice gathering no local SDP\n", pf_);
 				return;
 			}
 
@@ -1358,8 +1357,7 @@ public:
 			if (isdp)
 				invoke_gather(pf_, isdp);
 			else {
-				warning("pf(%p): ice candidate "
-					"no local SDP\n", pf_);
+				warning("pf(%p): ice candidate no local SDP\n", pf_);
 			}
 			return;
 		}
@@ -1392,8 +1390,7 @@ public:
 			if (isdp)
 				invoke_gather(pf_, isdp);
 			else {
-				warning("pf(%p): ice candidate "
-					"no local SDP\n", pf_);
+				warning("pf(%p): ice candidate no local SDP\n", pf_);
 				return;
 			}
 		}
@@ -1456,8 +1453,7 @@ public:
 			clientid = pf_->clientid_remote;
 		}
 		else {
-			warning("pf(%p); no conf member for label: %s\n",
-				pf_, label);
+			warning("pf(%p); no conf member for label: %s\n", pf_, label);
 			lock_rel(pf_->cml.lock);
 			goto out;
 		}
@@ -1857,7 +1853,7 @@ public:
 		     pf_, SdpTypeToString(type), pf_->peerConn.get());
 
 		if (!isdp->ToString(&sdp_str)) {
-			warning("pf(%p): ToString failed\n");
+			warning("pf(%p): ToString failed\n", pf_);
 			return;
 		}
 		
@@ -1869,7 +1865,7 @@ public:
 			err = sdp_dup(&sess, pf_->conv_type,
 				      sdp_str.c_str(), true);
 			if (err) {
-				warning("pf(%p): sdp_dup failed: %m\n", err);
+				warning("pf(%p): sdp_dup failed: %m\n", pf_, err);
 				return;
 			}
 
@@ -1892,7 +1888,7 @@ public:
 			err = sdp_dup(&sess, pf_->conv_type,
 				      sdp_str.c_str(), false);
 			if (err) {
-				warning("pf(%p): sdp_dup failed: %m\n", err);
+				warning("pf(%p): sdp_dup failed: %m\n",pf_ , err);
 				return;
 			}
 			
@@ -1919,7 +1915,7 @@ public:
 	}
 
 	virtual void OnFailure(webrtc::RTCError err) {
-		warning("pf(5p); SDP-Failure: %s\n", err.message());
+		warning("pf(%p); SDP-Failure: %s\n", pf_, err.message());
 	}
 
 private:
@@ -3212,7 +3208,7 @@ bool peerflow_has_video(const struct iflow *iflow)
 	const struct peerflow *pf = (const struct peerflow*)iflow;
 
 	if (!pf || !pf->peerConn) {
-		warning("pf(%p): has_video: no peerflow\n");
+		warning("pf(-): has_video: no peerflow\n");
 		return false;
 	}
 

--- a/test/test_network_quality_handler.cpp
+++ b/test/test_network_quality_handler.cpp
@@ -168,8 +168,8 @@ static void incoming_handler(const char *convid, uint32_t msg_time,
 		  cli->userId.c_str(), cli->clientId.c_str(),
 		  convid,
 		  userid);
-	// usleep(500 * 1000); // 100 ms
-	auto err = wcall_answer(cli->call->callee.wuser, convid, WCALL_CALL_TYPE_NORMAL, 0);
+
+	auto err = wcall_answer(cli->wuser, convid, WCALL_CALL_TYPE_NORMAL, 0);
 	ASSERT_EQ(0, err);
 }
 
@@ -208,8 +208,6 @@ static void close_handler(int reason,
 
 	if (cli->call->caller.state == Closed &&
 	    cli->call->callee.state == Closed) {
-
-		re_cancel();
 
 		// TEMPORARILY REMOVE:
 		//
@@ -407,8 +405,6 @@ public:
 
 TEST_F(NetworkQuality, settingHandlerMultipleTimes)
 {
-	// I do net get why we create the same user again. We have 123 as cally already
-	// If we need really this one we can unot destroy this at the end ore we have to give him a new ID
 	WUSER_HANDLE wuser = wcall_create_ex("user", "123", 0, "voe", NULL, NULL, NULL, NULL, NULL, NULL,
 		NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
@@ -421,9 +417,7 @@ TEST_F(NetworkQuality, settingHandlerMultipleTimes)
                         i,
                         NULL);
     }
-
-    // This is the main issue because test is flaky, and it is a race condition to the other user 123 we had already running!
-	// wcall_destroy(wuser);
+	wcall_destroy(wuser);
 }
 
 TEST_F(NetworkQuality, checkHandlerForDifferentIntervals)

--- a/test/test_network_quality_handler.cpp
+++ b/test/test_network_quality_handler.cpp
@@ -84,9 +84,9 @@ static void ready_handler(int version, void *arg)
 
 	info("[ %s.%s ] Ready.\n", cli->userId.c_str(), cli->clientId.c_str());
 
-	if (cli->call->caller.state == Ready && cli->call->callee.state == Ready) {
+	if (cli->call->caller.state == Ready && cli->call->callee.state == Ready && cli == &cli->call->caller) {
 		info("[ %s.%s ] Ready, all participants are ready\n", cli->userId.c_str(), cli->clientId.c_str());
-		int err = wcall_start(cli->wuser, cli->call->callId.c_str(), WCALL_CALL_TYPE_NORMAL,
+		int err = wcall_start(cli->call->caller.wuser, cli->call->callId.c_str(), WCALL_CALL_TYPE_NORMAL,
 				conv_type, 0, 0);
 		ASSERT_EQ(0, err);
     }
@@ -95,52 +95,66 @@ static void ready_handler(int version, void *arg)
 }
 
 static int send_handler(void *ctx, const char *convid,
-			const char *userid_self, const char *clientid_self,
-			const char *userid_dest, const char *clientid_dest,
-			const uint8_t *data, size_t len, int transient,
-		    int my_clients_only,
-			void *arg)
+                        const char *userid_self, const char *clientid_self,
+                        const char *userid_dest, const char *clientid_dest,
+                        const uint8_t *data, size_t len, int transient,
+                        int my_clients_only,
+                        void *arg)
 {
-	auto cli = (Client* )arg;
+	auto cli = (Client *)arg;
 
 	info("[ %s.%s ] {%s} Send message from %s.%s ---> %s.%s\n",
-		  cli->userId.c_str(), cli->clientId.c_str(),
-		  convid,
-		  userid_self, clientid_self,
-		  userid_dest, clientid_dest);
+	     cli->userId.c_str(), cli->clientId.c_str(),
+	     convid,
+	     userid_self, clientid_self,
+	     userid_dest, clientid_dest);
 
-    /* Reply with success */
-	wcall_resp(cli->wuser, 200, "", ctx);
 
-    const uint32_t curr_time = time(0);
-    if (NULL != userid_dest && NULL != clientid_dest) {
+	/* Reply with success */
+	// wcall_resp(cli->wuser, 200, "", ctx);
+	if (cli->call->callee.userId != userid_self) {
+		wcall_resp(cli->call->caller.wuser, 200, "", ctx);
+	} else {
+		wcall_resp(cli->call->callee.wuser, 200, "", ctx);
+	}
+	const uint32_t curr_time = time(0);
+
+	if (NULL != userid_dest && NULL != clientid_dest) {
 		warning("[ %s.%s ] {%s} Implement Me \n",
-            cli->userId.c_str(), cli->clientId.c_str(), convid);
-    } else {
-        if (cli->call->callee.userId != userid_self) {
-            // send message to callee
-			wcall_recv_msg(cli->call->callee.wuser, data, len,
-				curr_time,
-				curr_time,
-				convid,
-				userid_self,
-				clientid_self,
-				WCALL_CONV_TYPE_CONFERENCE_MLS,
-				false);
-        }
-        if (cli->call->caller.userId != userid_self) {
-            // send message to callee
-			wcall_recv_msg(cli->call->caller.wuser, data, len,
-				curr_time,
-				curr_time,
-				convid,
-				userid_self,
-				clientid_self,
-				WCALL_CONV_TYPE_CONFERENCE_MLS,
-				false);
-        }
-    }
-    return 0;
+		        cli->userId.c_str(),
+		        cli->clientId.c_str(),
+		        convid);
+	} else {
+		if (cli->call->callee.userId != userid_self) {
+			// send message to callee
+			wcall_recv_msg(
+					cli->call->callee.wuser,
+					data,
+					len,
+					curr_time,
+					curr_time,
+					convid,
+					userid_self,
+					clientid_self,
+					WCALL_CONV_TYPE_GROUP,
+					false);
+		}
+		if (cli->call->caller.userId != userid_self) {
+			// send message to callee
+			wcall_recv_msg(
+					cli->call->caller.wuser,
+					data,
+					len,
+					curr_time,
+					curr_time,
+					convid,
+					userid_self,
+					clientid_self,
+					WCALL_CONV_TYPE_GROUP,
+					false);
+		}
+	}
+	return 0;
 }
 
 static void incoming_handler(const char *convid, uint32_t msg_time,
@@ -154,7 +168,8 @@ static void incoming_handler(const char *convid, uint32_t msg_time,
 		  cli->userId.c_str(), cli->clientId.c_str(),
 		  convid,
 		  userid);
-    auto err = wcall_answer(cli->wuser, convid, WCALL_CALL_TYPE_NORMAL, 0);
+	// usleep(500 * 1000); // 100 ms
+	auto err = wcall_answer(cli->call->callee.wuser, convid, WCALL_CALL_TYPE_NORMAL, 0);
 	ASSERT_EQ(0, err);
 }
 
@@ -177,28 +192,30 @@ static void estab_handler(const char *convid,
 }
 
 
-static void close_handler(int reason, const char *convid, uint32_t msg_time,
-			  const char *userid, const char *clientid, void *arg)
+static void close_handler(int reason,
+                          const char *convid,
+                          uint32_t msg_time,
+                          const char *userid,
+                          const char *clientid,
+                          void *arg)
 {
 	auto cli = (Client *)arg;
 	auto closeReason = std::string(wcall_reason_name(reason));
-
-	info("[ %s.%s ] {%s} Closed handler (%s)\n",
-		cli->userId.c_str(), cli->clientId.c_str(),
-		convid,
-		closeReason.c_str());
 
 	if (closeReason == "Normal") {
 		cli->state = Closed;
 	}
 
-	if (cli->call->caller.state == Closed && cli->call->callee.state == Closed) {
-		info("[ %s.%s ] {%s} Closed handler, all participants are closed\n",
-			cli->userId.c_str(), cli->clientId.c_str(), convid);
+	if (cli->call->caller.state == Closed &&
+	    cli->call->callee.state == Closed) {
 
-		wcall_destroy(cli->call->caller.wuser);
-		wcall_destroy(cli->call->callee.wuser);
-    }
+		re_cancel();
+
+		// TEMPORARILY REMOVE:
+		//
+		 wcall_destroy(cli->call->caller.wuser);
+		 wcall_destroy(cli->call->callee.wuser);
+	}
 }
 
 // {..., "quality":1, ...}
@@ -298,7 +315,7 @@ bool is_valid_quality_json(const char *quality_info) {
 		return false;
 	}
 
-	const auto is_valid = 
+	const auto is_valid =
 		has_valid_quality_indication(jobj) &&
 		has_valid_rtt(jobj) &&
 		has_valid_packet_loss(jobj) &&
@@ -356,7 +373,7 @@ static void set_quality_interval(void *arg)
 static void cleanup_function(void *arg)
 {
 	auto call = (SimpleCall *)arg;
-	wcall_end(call->caller.wuser, call->callId.c_str());
+	wcall_end(call->callee.wuser, call->callId.c_str());
 }
 
 
@@ -390,6 +407,8 @@ public:
 
 TEST_F(NetworkQuality, settingHandlerMultipleTimes)
 {
+	// I do net get why we create the same user again. We have 123 as cally already
+	// If we need really this one we can unot destroy this at the end ore we have to give him a new ID
 	WUSER_HANDLE wuser = wcall_create_ex("user", "123", 0, "voe", NULL, NULL, NULL, NULL, NULL, NULL,
 		NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
@@ -403,7 +422,8 @@ TEST_F(NetworkQuality, settingHandlerMultipleTimes)
                         NULL);
     }
 
-	wcall_destroy(wuser);
+    // This is the main issue because test is flaky, and it is a race condition to the other user 123 we had already running!
+	// wcall_destroy(wuser);
 }
 
 TEST_F(NetworkQuality, checkHandlerForDifferentIntervals)


### PR DESCRIPTION
##  What is in this PR
Fix duplicate user cleanup. A user could be created twice, and timing out one instance incorrectly destroyed both, causing a segfault during call cleanup.

